### PR TITLE
Corrected "iPad 2 (GSM)"

### DIFF
--- a/Source/JTSHardwareInfo.m
+++ b/Source/JTSHardwareInfo.m
@@ -500,7 +500,7 @@ static NSString * JTSHardwareInfo_HardwareIdentifier_iPodTouch_6G       = @"iPod
             displayName = @"iPad 2 (CDMA)";
             break;
         case JTSHardwareType_iPad_2_GSM:
-            displayName = @"iPad (GSM)";
+            displayName = @"iPad 2 (GSM)";
             break;
         case JTSHardwareType_iPad_2_WiFi:
             displayName = @"iPad 2 (WiFi)";


### PR DESCRIPTION
JTSHardwareType_iPad_2_GSM was reporting as "iPad (GSM)"